### PR TITLE
[#64] Remove support for tha_hooks

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -23,7 +23,6 @@ if ( post_password_required() ) {
 <div class="clear">
 
 </div>
-<?php tha_comments_before(); ?>
 <div id="comments" class="comments__area">
 
 	<?php if ( have_comments() ) : ?>
@@ -112,4 +111,3 @@ if ( post_password_required() ) {
 	<?php comment_form(); ?>
 
 </div>
-<?php tha_comments_after(); ?>

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
       }
     ],
     "require": {
-      "moxie-leean/theme-assets": "dev-master",
-      "zamoose/themehookalliance": "dev-master"
+      "moxie-leean/theme-assets": "dev-master"
     },
     "require-dev": {
       "squizlabs/php_codesniffer": "2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "aee39a6a647ba5cc2b2e6064c68d0aa7",
-    "content-hash": "f53fe990568364d6bc13ff5eb3e2ea56",
+    "hash": "7367b5938cadc9e241ae4bc98d7f9254",
+    "content-hash": "33a156ccf5da48db9a767623a74c5761",
     "packages": [
         {
             "name": "moxie-leean/theme-assets",
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/moxie-leean/theme-assets.git",
-                "reference": "15efde64962b3f721ea4333767145477002be358"
+                "reference": "d56c773d20f7be2b7f69a8efd33f10bc770d3dfe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/moxie-leean/theme-assets/zipball/15efde64962b3f721ea4333767145477002be358",
-                "reference": "15efde64962b3f721ea4333767145477002be358",
+                "url": "https://api.github.com/repos/moxie-leean/theme-assets/zipball/d56c773d20f7be2b7f69a8efd33f10bc770d3dfe",
+                "reference": "d56c773d20f7be2b7f69a8efd33f10bc770d3dfe",
                 "shasum": ""
             },
             "require": {
@@ -53,39 +53,7 @@
                 "scripts",
                 "wordpress"
             ],
-            "time": "2016-01-05 02:06:16"
-        },
-        {
-            "name": "zamoose/themehookalliance",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zamoose/themehookalliance.git",
-                "reference": "969c949df8c0a9740f27b88755d053762be5d283"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zamoose/themehookalliance/zipball/969c949df8c0a9740f27b88755d053762be5d283",
-                "reference": "969c949df8c0a9740f27b88755d053762be5d283",
-                "shasum": ""
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Doug Stewart",
-                    "homepage": "http://literalbarrage.org"
-                }
-            ],
-            "description": "Theme Hook Alliance",
-            "homepage": "https://github.com/zamoose/themehookalliance",
-            "keywords": [
-                "wordpress"
-            ],
-            "time": "2015-08-05 03:42:29"
+            "time": "2016-01-07 04:58:20"
         }
     ],
     "packages-dev": [
@@ -207,7 +175,6 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "moxie-leean/theme-assets": 20,
-        "zamoose/themehookalliance": 20,
         "wp-coding-standards/wpcs": 20
     },
     "prefer-stable": false,

--- a/config/dependencies.php
+++ b/config/dependencies.php
@@ -7,15 +7,9 @@
  */
 function load_dependencies() {
 	/*
-	 * Including Theme Hook Alliance
-	 *
-	 * @linkg https://github.com/zamoose/themehookalliance.
-	 *
-	 * Use add_theme_support( 'tha_hooks', array('all') ) to add support.
+	 * Require of the autoloading of composer.
 	 */
 	require COMPOSER . '/autoload.php';
-	require COMPOSER . '/zamoose/themehookalliance/tha-theme-hooks.php';
-
 	/*
 	 * Custom template tags for this theme.
 	 */

--- a/footer.php
+++ b/footer.php
@@ -7,13 +7,9 @@
  */
 
 ?>
-		<?php tha_content_bottom(); ?>
 
-		<?php tha_content_after(); ?>
-   		<?php tha_footer_before(); ?>
 		<footer id="colophon" class="footer" role="contentinfo"
 			itemscope="itemscope" itemtype="http://schema.org/WPFooter">
-			<?php tha_footer_top(); ?>
 			<div class="footer__info">
 				<a href="http://wordpress.org/" rel="generator">
 				<?php
@@ -23,12 +19,9 @@
 				<span class="genericon genericon-wordpress"></span> Wordpress
 				</a>
 			</div>
-			<?php tha_footer_bottom(); ?>
 		</footer>
-		<?php tha_footer_after(); ?>
 	</div>
 
-<?php tha_body_bottom(); ?>
 <?php wp_footer(); ?>
 </body>
 </html>

--- a/functions.php
+++ b/functions.php
@@ -17,8 +17,6 @@ add_action( 'after_setup_theme', function(){
 	// Make theme available for translation.
 	load_theme_textdomain( TRANSLATED_TEXT_DOMAIN , \Leean\THEME_PATH . '/config/languages' );
 	add_theme_support( 'post-thumbnails' );
-	// Add support for all the hooks from tha_hooks.
-	add_theme_support( 'tha_hooks', array( 'all' ) );
 	// Add Editor Style for adequate styling in text editor.
 	if ( defined( 'WP_DEBUG' ) && true === WP_DEBUG ) {
 		add_editor_style( \Leean\EDITOR_STYLESHEET_UNMINIFIED );

--- a/header.php
+++ b/header.php
@@ -8,27 +8,21 @@
 
 ?>
 <!DOCTYPE html>
-<?php tha_html_before(); ?>
 <html <?php language_attributes(); ?>>
 <head>
-	<?php tha_head_top(); ?>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title><?php wp_title( '|', true, 'right' ); ?></title>
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 
-	<?php tha_head_bottom(); ?>
 	<?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>
-<?php tha_body_top(); ?>
 <div id="page" class="hfeed site">
 	<div class="wrap">
-		<?php tha_header_before(); ?>
 		<header id="masthead" class="header" role="banner"
 				itemscope="itemscope" itemtype="http://schema.org/WPHeader">
-			<?php tha_header_top(); ?>
 			<div class="header__branding">
 				<div class="header__title">
 					<h1>
@@ -53,10 +47,5 @@
 				wp_nav_menu( $args );
 				?>
 			</nav>
-			<?php tha_header_bottom(); ?>
 
 		</header>
-		<?php tha_header_after(); ?>
-
-		<?php tha_content_before(); ?>
-			<?php tha_content_top(); ?>

--- a/partials/content-none.php
+++ b/partials/content-none.php
@@ -10,16 +10,13 @@
  */
 
 ?>
-<?php tha_entry_before(); ?>
 <section class="no-results not-found">
 	<header>
 		<h1>
 			<?php esc_html_e( 'Nothing Found', TRANSLATED_TEXT_DOMAIN ); ?>
 		</h1>
 	</header>
-	<?php tha_content_before(); ?>
 	<div class="page__content">
-		<?php tha_entry_top(); ?>
 		<?php if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 			<p>
 			<?php
@@ -65,8 +62,5 @@
 			<?php get_search_form(); ?>
 
 		<?php endif; ?>
-		<?php tha_entry_bottom(); ?>
 	</div>
-	<?php tha_content_after(); ?>
 </section>
-<?php tha_entry_after(); ?>

--- a/partials/content-page.php
+++ b/partials/content-page.php
@@ -8,10 +8,8 @@
  */
 
 ?>
-<?php tha_entry_before(); ?>
 <article class="entry" id="post-<?php the_ID(); ?>" <?php post_class(); ?>
 	itemscope itemType="http://schema.org/WebPage">
-	<?php tha_entry_top(); ?>
 	<header class="entry__header">
 
 		<h1 class="entry__title" itemprop="name"><?php the_title(); ?></h1>
@@ -46,6 +44,4 @@
 			'<span class="edit__link">', '</span>'
 		);
 	?>
-	<?php tha_entry_bottom(); ?>
 </article>
-<?php tha_entry_after(); ?>

--- a/partials/content-single.php
+++ b/partials/content-single.php
@@ -9,10 +9,8 @@
 
 use Leean\Inc\Helpers;
 ?>
-<?php tha_entry_before(); ?>
 <article class="entry" id="post-<?php the_ID(); ?>" <?php post_class(); ?>
 	itemscope itemType="http://schema.org/BlogPosting">
-	<?php tha_entry_top(); ?>
 	<header class="entry__header">
 		<h1 class="entry__title" itemprop="name"><?php the_title(); ?></h1>
 	</header>
@@ -97,6 +95,4 @@ use Leean\Inc\Helpers;
 			);
 		?>
 	</footer>
-	<?php tha_entry_bottom(); ?>
 </article>
-<?php tha_entry_after(); ?>

--- a/partials/content.php
+++ b/partials/content.php
@@ -9,10 +9,8 @@
 
 ?>
 
-<?php tha_entry_before(); ?>
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>
 		itemscope itemType="http://schema.org/BlogPosting">
-	<?php tha_entry_top(); ?>
 	<header class="entry__header">
 
 		<h1 class="entry__title" itemprop="name">
@@ -72,6 +70,4 @@
 			);
 		?>
 	</footer>
-	<?php tha_entry_bottom(); ?>
 </article>
-<?php tha_entry_after(); ?>

--- a/sidebar.php
+++ b/sidebar.php
@@ -5,12 +5,10 @@
  * @package Leean
  */
 
-tha_sidebars_before();
 ?>
 
 <div id="secondary" role="complementary">
 
-	<?php tha_sidebar_top(); ?>
 
 	<?php do_action( 'before_sidebar' ); ?>
 
@@ -48,8 +46,4 @@ tha_sidebars_before();
 
 <?php endif; ?>
 
-<?php tha_sidebar_bottom(); ?>
-
 </div>
-
-<?php tha_sidebars_after(); ?>


### PR DESCRIPTION
Since most of this hooks are for distribution themes and this theme is
mainly used for single purpose or custom clients we don't require most
of the hooks provied by tha_hooks
